### PR TITLE
规范化命名

### DIFF
--- a/packages/unify_unipage/README.md
+++ b/packages/unify_unipage/README.md
@@ -1,4 +1,4 @@
-# unify_unipage
+# unify_uni_page
 
 A new Flutter project.
 
@@ -12,4 +12,3 @@ Android and/or iOS.
 For help getting started with Flutter, view our
 [online documentation](https://flutter.dev/docs), which offers tutorials,
 samples, guidance on mobile development, and a full API reference.
-

--- a/packages/unify_unipage/android/build.gradle
+++ b/packages/unify_unipage/android/build.gradle
@@ -1,4 +1,4 @@
-group 'com.didi.unify_unipage'
+group 'com.didi.unify_uni_page'
 version '1.0'
 
 buildscript {

--- a/packages/unify_unipage/android/settings.gradle
+++ b/packages/unify_unipage/android/settings.gradle
@@ -1,1 +1,1 @@
-rootProject.name = 'unify_unipage'
+rootProject.name = 'unify_uni_page'

--- a/packages/unify_unipage/android/src/main/AndroidManifest.xml
+++ b/packages/unify_unipage/android/src/main/AndroidManifest.xml
@@ -1,3 +1,3 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="com.didi.unify_unipage">
+  package="com.didi.unify_uni_page">
 </manifest>

--- a/packages/unify_unipage/android/src/main/java/com/didi/unify_uni_page/AbsUniPageFactory.java
+++ b/packages/unify_unipage/android/src/main/java/com/didi/unify_uni_page/AbsUniPageFactory.java
@@ -1,4 +1,4 @@
-package com.didi.unify_unipage;
+package com.didi.unify_uni_page;
 
 import android.content.Context;
 

--- a/packages/unify_unipage/android/src/main/java/com/didi/unify_uni_page/Constants.java
+++ b/packages/unify_unipage/android/src/main/java/com/didi/unify_uni_page/Constants.java
@@ -1,7 +1,7 @@
-package com.didi.unify_unipage;
+package com.didi.unify_uni_page;
 
 public class Constants {
-    public static final String UNI_PAGE_CHANNEL = "com.didi.unify.unipage";
+    public static final String UNI_PAGE_CHANNEL = "com.didi.unify.uni_page";
     public static final String UNI_PAGE_ROUTE_PUSH_NAMED = "pushNamed";
     public static final String UNI_PAGE_ROUTE_POP = "pop";
     public static final String UNI_PAGE_CHANNEL_PARAMS_PATH = "path";

--- a/packages/unify_unipage/android/src/main/java/com/didi/unify_uni_page/UniPage.java
+++ b/packages/unify_unipage/android/src/main/java/com/didi/unify_uni_page/UniPage.java
@@ -1,4 +1,4 @@
-package com.didi.unify_unipage;
+package com.didi.unify_uni_page;
 
 import android.content.Context;
 import android.view.View;

--- a/packages/unify_unipage/android/src/main/java/com/didi/unify_uni_page/UnifyUniPagePlugin.java
+++ b/packages/unify_unipage/android/src/main/java/com/didi/unify_uni_page/UnifyUniPagePlugin.java
@@ -1,4 +1,4 @@
-package com.didi.unify_unipage;
+package com.didi.unify_uni_page;
 
 import androidx.annotation.NonNull;
 

--- a/packages/unify_unipage/android/src/main/java/com/didi/unify_unipage/IUniPageMethod.java
+++ b/packages/unify_unipage/android/src/main/java/com/didi/unify_unipage/IUniPageMethod.java
@@ -1,7 +1,0 @@
-package com.didi.unify_unipage;
-
-import java.util.Map;
-
-public interface IUniPageMethod {
-    Object call(Map<String, Object> params);
-}

--- a/packages/unify_unipage/example/README.md
+++ b/packages/unify_unipage/example/README.md
@@ -1,6 +1,6 @@
-# unify_unipage_example
+# unify_uni_page_example
 
-Demonstrates how to use the unify_unipage plugin.
+Demonstrates how to use the unify_uni_page plugin.
 
 ## Getting Started
 

--- a/packages/unify_unipage/example/android/app/build.gradle
+++ b/packages/unify_unipage/example/android/app/build.gradle
@@ -35,7 +35,7 @@ android {
 
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
-        applicationId "com.didi.unify_unipage_example"
+        applicationId "com.didi.unify_uni_page_example"
         minSdkVersion flutter.minSdkVersion
         targetSdkVersion flutter.targetSdkVersion
         versionCode flutterVersionCode.toInteger()

--- a/packages/unify_unipage/example/android/app/src/debug/AndroidManifest.xml
+++ b/packages/unify_unipage/example/android/app/src/debug/AndroidManifest.xml
@@ -1,7 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.didi.unify_unipage_example">
+    package="com.didi.unify_uni_page_example">
     <!-- Flutter needs it to communicate with the running application
          to allow setting breakpoints, to provide hot reload, etc.
     -->
-    <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission android:name="android.permission.INTERNET" />
 </manifest>

--- a/packages/unify_unipage/example/android/app/src/main/AndroidManifest.xml
+++ b/packages/unify_unipage/example/android/app/src/main/AndroidManifest.xml
@@ -1,7 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.didi.unify_unipage_example">
-   <application
-        android:label="unify_unipage_example"
+    package="com.didi.unify_uni_page_example">
+    <application
+        android:label="unify_uni_page_example"
         android:name=".MainApplication"
         android:icon="@mipmap/ic_launcher">
         <activity
@@ -17,12 +17,12 @@
                  while the Flutter UI initializes. After that, this theme continues
                  to determine the Window background behind the Flutter UI. -->
             <meta-data
-              android:name="io.flutter.embedding.android.NormalTheme"
-              android:resource="@style/NormalTheme"
-              />
+                android:name="io.flutter.embedding.android.NormalTheme"
+                android:resource="@style/NormalTheme"
+            />
             <intent-filter>
-                <action android:name="android.intent.action.MAIN"/>
-                <category android:name="android.intent.category.LAUNCHER"/>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
         <!-- Don't delete the meta-data below.

--- a/packages/unify_unipage/example/android/app/src/main/java/com/didi/unify_uni_page_example/MainActivity.java
+++ b/packages/unify_unipage/example/android/app/src/main/java/com/didi/unify_uni_page_example/MainActivity.java
@@ -1,4 +1,4 @@
-package com.didi.unify_unipage_example;
+package com.didi.unify_uni_page_example;
 
 import io.flutter.embedding.android.FlutterActivity;
 

--- a/packages/unify_unipage/example/android/app/src/main/java/com/didi/unify_uni_page_example/MainApplication.java
+++ b/packages/unify_unipage/example/android/app/src/main/java/com/didi/unify_uni_page_example/MainApplication.java
@@ -1,7 +1,7 @@
-package com.didi.unify_unipage_example;
+package com.didi.unify_uni_page_example;
 
-import com.didi.unify_unipage.UnifyUniPagePlugin;
-import com.didi.unify_unipage_example.unipages.UniPageDemo;
+import com.didi.unify_uni_page.UnifyUniPagePlugin;
+import com.didi.unify_uni_page_example.uni_pages.UniPageDemo;
 
 import io.flutter.app.FlutterApplication;
 

--- a/packages/unify_unipage/example/android/app/src/main/java/com/didi/unify_uni_page_example/unipages/UniPageDemo.java
+++ b/packages/unify_unipage/example/android/app/src/main/java/com/didi/unify_uni_page_example/unipages/UniPageDemo.java
@@ -1,4 +1,4 @@
-package com.didi.unify_unipage_example.unipages;
+package com.didi.unify_uni_page_example.uni_pages;
 
 import android.util.Log;
 import android.view.View;
@@ -6,7 +6,7 @@ import android.widget.Button;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 
-import com.didi.unify_unipage.UniPage;
+import com.didi.unify_uni_page.UniPage;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -61,7 +61,7 @@ public class UniPageDemo extends UniPage {
         btnUpdateTitleBar.setText("update Flutter titlebar");
         btnUpdateTitleBar.setOnClickListener(view -> {
             HashMap<String, Object> params = new HashMap<>();
-            params.put("title", "Updated from native unipage!");
+            params.put("title", "Updated from native UniPage!");
             invoke("updateTitleBar", params);
         });
         ll.addView(btnUpdateTitleBar);
@@ -72,7 +72,7 @@ public class UniPageDemo extends UniPage {
 
         // update Flutter Titlebar directly when onCreate
         HashMap<String, Object> params = new HashMap<>();
-        params.put("title", "Updated tilebar na unipage onCreate");
+        params.put("title", "Updated tilebar na UniPage onCreate");
         invoke("updateTitleBar", params);
 
 

--- a/packages/unify_unipage/example/android/app/src/profile/AndroidManifest.xml
+++ b/packages/unify_unipage/example/android/app/src/profile/AndroidManifest.xml
@@ -1,7 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.didi.unify_unipage_example">
+    package="com.didi.unify_uni_page_example">
     <!-- Flutter needs it to communicate with the running application
          to allow setting breakpoints, to provide hot reload, etc.
     -->
-    <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission android:name="android.permission.INTERNET" />
 </manifest>

--- a/packages/unify_unipage/example/lib/main.dart
+++ b/packages/unify_unipage/example/lib/main.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 
-import 'package:unify_unipage_example/page/flutter_hello_page.dart';
-import 'package:unify_unipage_example/unipage/uni_page_demo.dart';
+import 'package:unify_uni_page_example/page/flutter_hello_page.dart';
+import 'package:unify_uni_page_example/unipage/uni_page_demo.dart';
 
 import 'home_page.dart';
 

--- a/packages/unify_unipage/example/lib/unipage/uni_page_demo.dart
+++ b/packages/unify_unipage/example/lib/unipage/uni_page_demo.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:unify_unipage/unify_unipage.dart';
+import 'package:unify_uni_page/unify_uni_page.dart';
 
 class UniPageDemo extends StatefulWidget {
   const UniPageDemo({Key? key}) : super(key: key);

--- a/packages/unify_unipage/example/pubspec.lock
+++ b/packages/unify_unipage/example/pubspec.lock
@@ -163,7 +163,7 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.3.0"
-  unify_unipage:
+  unify_uni_page:
     dependency: "direct main"
     description:
       path: ".."

--- a/packages/unify_unipage/example/pubspec.yaml
+++ b/packages/unify_unipage/example/pubspec.yaml
@@ -1,9 +1,9 @@
-name: unify_unipage_example
-description: Demonstrates how to use the unify_unipage plugin.
+name: unify_uni_page_example
+description: Demonstrates how to use the unify_uni_page plugin.
 
 # The following line prevents the package from being accidentally published to
 # pub.dev using `flutter pub publish`. This is preferred for private packages.
-publish_to: 'none' # Remove this line if you wish to publish to pub.dev
+publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
 environment:
   sdk: ">=2.16.2 <3.0.0"
@@ -18,9 +18,9 @@ dependencies:
   flutter:
     sdk: flutter
 
-  unify_unipage:
+  unify_uni_page:
     # When depending on this package from a real application you should use:
-    #   unify_unipage: ^x.y.z
+    #   unify_uni_page: ^x.y.z
     # See https://dart.dev/tools/pub/dependencies#version-constraints
     # The example app is bundled with the plugin so we use a path dependency on
     # the parent directory to use the current plugin's version.
@@ -46,7 +46,6 @@ dev_dependencies:
 
 # The following section is specific to Flutter.
 flutter:
-
   # The following line ensures that the Material Icons font is
   # included with your application, so that you can use the icons in
   # the material Icons class.

--- a/packages/unify_unipage/example/test/widget_test.dart
+++ b/packages/unify_unipage/example/test/widget_test.dart
@@ -8,7 +8,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'package:unify_unipage_example/main.dart';
+import 'package:unify_uni_page_example/main.dart';
 
 void main() {
   testWidgets('Verify Platform version', (WidgetTester tester) async {
@@ -18,8 +18,8 @@ void main() {
     // Verify that platform version is retrieved.
     expect(
       find.byWidgetPredicate(
-        (Widget widget) => widget is Text &&
-                           widget.data!.startsWith('Running on:'),
+        (Widget widget) =>
+            widget is Text && widget.data!.startsWith('Running on:'),
       ),
       findsOneWidget,
     );

--- a/packages/unify_unipage/lib/src/constants.dart
+++ b/packages/unify_unipage/lib/src/constants.dart
@@ -1,4 +1,4 @@
-const String kUniPageChannel = 'com.didi.unify.unipage';
+const String kUniPageChannel = 'com.didi.unify.uni_page';
 const String kChannelRoutePushNamed = 'pushNamed';
 const String kChannelRoutePop = 'pop';
 const String kChannelInvoke = 'invoke';

--- a/packages/unify_unipage/lib/src/uni_page.dart
+++ b/packages/unify_unipage/lib/src/uni_page.dart
@@ -5,10 +5,11 @@ import 'package:flutter/gestures.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
-import 'package:unify_unipage/unify_unipage.dart';
+import 'package:unify_uni_page/unify_uni_page.dart';
 
 class UniPage extends StatelessWidget {
-  const UniPage(this.viewType, {Key? key, this.createParams, required this.controller})
+  const UniPage(this.viewType,
+      {Key? key, this.createParams, required this.controller})
       : super(key: key);
 
   final String viewType;
@@ -34,8 +35,8 @@ class UniPage extends StatelessWidget {
           return AndroidViewSurface(
               controller: controller as AndroidViewController,
               hitTestBehavior: PlatformViewHitTestBehavior.opaque,
-              gestureRecognizers: const <
-                  Factory<OneSequenceGestureRecognizer>>{});
+              gestureRecognizers: const <Factory<
+                  OneSequenceGestureRecognizer>>{});
         },
         onCreatePlatformView: (params) {
           controller?.init(context, viewType, params.id);

--- a/packages/unify_unipage/lib/src/uni_page_controller.dart
+++ b/packages/unify_unipage/lib/src/uni_page_controller.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
-import 'package:unify_unipage/src/constants.dart';
+import 'package:unify_uni_page/src/constants.dart';
 
 typedef MethodCallHandler = Future<dynamic> Function(
     String methodName, Map<String, dynamic> prams);

--- a/packages/unify_unipage/lib/unify_uni_page.dart
+++ b/packages/unify_unipage/lib/unify_uni_page.dart
@@ -1,0 +1,2 @@
+export 'src/uni_page.dart';
+export 'src/uni_page_controller.dart';

--- a/packages/unify_unipage/lib/unify_unipage.dart
+++ b/packages/unify_unipage/lib/unify_unipage.dart
@@ -1,2 +1,0 @@
-export 'src/unipage.dart';
-export 'src/unipage_controller.dart';

--- a/packages/unify_unipage/pubspec.yaml
+++ b/packages/unify_unipage/pubspec.yaml
@@ -1,4 +1,4 @@
-name: unify_unipage
+name: unify_uni_page
 description: A new Flutter project.
 version: 0.0.1
 homepage:
@@ -28,10 +28,10 @@ flutter:
   plugin:
     platforms:
       android:
-        package: com.didi.unify_unipage
+        package: com.didi.unify_uni_page
         pluginClass: UnifyUniPagePlugin
       ios:
-        pluginClass: UnifyUnipagePlugin
+        pluginClass: UnifyUniPagePlugin
 
   # To add assets to your plugin package, add an assets section, like this:
   # assets:

--- a/packages/unify_unipage/test/unify_unipage_test.dart
+++ b/packages/unify_unipage/test/unify_unipage_test.dart
@@ -2,7 +2,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  const MethodChannel channel = MethodChannel('unify_unipage');
+  const MethodChannel channel = MethodChannel('unify_uni_page');
 
   TestWidgetsFlutterBinding.ensureInitialized();
 


### PR DESCRIPTION
现有的 `unipage` 写法，不够规范，会导致 lint 语法检测报错。

在这个 PR 中，对所有 Dart、Android 代码中的 `unipage` 写法进行了规范。

具体包括以下两条准则：

1. 需要驼峰的地方，统一改为 `UniPage`
2. 需要下划线的地方，统一改名 `uni_page`

包名也已修改为 `unify_uni_page`

后续 Todo：在 iOS 侧，需要对 iOS 代码进行同样的批量替换。