### PR TITLE
fix: Fixed the issue of using UniPage in a new container on the C-end, where UniPage was not released when the container was closed directly. Compatible with sideslip return scenarios in mixed routing.

### DIFF
--- a/packages/unify_uni_page/ios/Classes/AbsUniPageFactory.h
+++ b/packages/unify_uni_page/ios/Classes/AbsUniPageFactory.h
@@ -10,10 +10,10 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@class UniPage;
+@class UniPageContainer;
 
 // 别名定义
-typedef UniPage* _Nonnull (^UniPageFactoryCallback)(CGRect frame, int64_t viewId, NSDictionary *args);
+typedef UniPageContainer* _Nonnull (^UniPageFactoryCallback)(CGRect frame, int64_t viewId, NSDictionary *args);
 
 @interface AbsUniPageFactory : NSObject<FlutterPlatformViewFactory>
 

--- a/packages/unify_uni_page/ios/Classes/AbsUniPageFactory.m
+++ b/packages/unify_uni_page/ios/Classes/AbsUniPageFactory.m
@@ -7,6 +7,7 @@
 
 #import "AbsUniPageFactory.h"
 #import "UniPage.h"
+#import "UniPageContainer.h"
 
 @interface AbsUniPageFactory()
 
@@ -29,7 +30,8 @@
 - (NSObject<FlutterPlatformView>*)createWithFrame:(CGRect)frame
                                    viewIdentifier:(int64_t)viewId
                                         arguments:(id _Nullable)args {
-    return self.block(frame, viewId, args);
+    id<FlutterPlatformView> embededView = self.block(frame, viewId, args);
+    return embededView;
 }
 
 - (NSObject<FlutterMessageCodec> *)createArgsCodec {

--- a/packages/unify_uni_page/ios/Classes/UIView+GetController.h
+++ b/packages/unify_uni_page/ios/Classes/UIView+GetController.h
@@ -1,0 +1,18 @@
+//
+//  UIView+GetController.h
+//  unify_uni_page
+//
+//  Created by jerry on 2024/10/17.
+//
+
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface UIView (GetController)
+
+- (UIViewController *)currentController;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/unify_uni_page/ios/Classes/UIView+GetController.m
+++ b/packages/unify_uni_page/ios/Classes/UIView+GetController.m
@@ -1,0 +1,23 @@
+//
+//  UIView+GetController.m
+//  unify_uni_page
+//
+//  Created by jerry on 2024/10/17.
+//
+
+#import "UIView+GetController.h"
+
+@implementation UIView (GetController)
+
+- (UIViewController *)currentController {
+    UIResponder *next = [self nextResponder];
+    do {
+        if ([next isKindOfClass:[UIViewController class]]) {
+            return (UIViewController *)next;
+        }
+        next = [next nextResponder];
+    } while (next != nil);
+    return nil;
+}
+
+@end

--- a/packages/unify_uni_page/ios/Classes/UniPage.h
+++ b/packages/unify_uni_page/ios/Classes/UniPage.h
@@ -7,16 +7,13 @@
 
 #import <UIKit/UIKit.h>
 #import <Flutter/Flutter.h>
+#import "UniPageProtocol.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface UniPage : UIView<FlutterPlatformView>
+@interface UniPage : UIView
 
-- (instancetype)initWithWithFrame:(CGRect)frame
-                         viewType:(NSString*)viewType
-                   viewIdentifier:(int64_t)viewId
-                        arguments:(NSDictionary *)args
-                  binaryMessenger:(NSObject<FlutterBinaryMessenger>*)messenger;
+@property (nonatomic, weak) id<UniPageProtocol> delegate;
 
 - (void)pushNamed:(NSString*)routePath param:(NSDictionary*)args;
 
@@ -68,6 +65,10 @@ NS_ASSUME_NONNULL_BEGIN
 ///   - methodName: 方法名 / 事件名
 ///   - args: 收到的参数
 - (id)onMethodCall:(NSString*)methodName params:(NSDictionary *)args;
+
+
+/// 获取当前视图被添加在哪个VC上的id标识，返回hash值
+- (NSUInteger)getOwnerId;
 
 @end
 

--- a/packages/unify_uni_page/ios/Classes/UniPage.m
+++ b/packages/unify_uni_page/ios/Classes/UniPage.m
@@ -7,14 +7,12 @@
 
 #import "UniPage.h"
 #import "UniPageConstants.h"
+#import "UIView+GetController.h"
 
-@interface UniPage()<FlutterPlatformView>
+@interface UniPage()
 
-@property (nonatomic, copy) NSString *viewType;
-@property (nonatomic, assign) int64_t viewId;
-@property (nonatomic, strong) NSDictionary *arguments;
-@property (nonatomic, strong) FlutterMethodChannel *channel;
 @property (nonatomic, assign) BOOL isPosted;
+@property (nonatomic, assign) NSUInteger ownerId;
 
 @end
 
@@ -22,37 +20,7 @@
 
 - (void)dealloc {
     [[NSNotificationCenter defaultCenter] removeObserver:self];
-    [self onDispose];
-}
-
-- (instancetype)initWithWithFrame:(CGRect)frame
-                         viewType:(NSString*)viewType
-                   viewIdentifier:(int64_t)viewId
-                        arguments:(NSDictionary *)args
-                  binaryMessenger:(NSObject<FlutterBinaryMessenger>*)messenger {
-    if ([super init]) {
-        self.viewId = viewId;
-        self.viewType = viewType;
-        self.arguments = args;
-        self.channel = [FlutterMethodChannel methodChannelWithName:[self createChannelName:viewType viewId:viewId] binaryMessenger:messenger];
-        __weak __typeof(self) weakSelf = self;
-        [self.channel setMethodCallHandler:^(FlutterMethodCall * _Nonnull call, FlutterResult  _Nonnull result) {
-            __strong __typeof(weakSelf) strongSelf = weakSelf;
-            [strongSelf onMethodCall:call result:result];
-        }];
-        
-        NSNotificationCenter* center = [NSNotificationCenter defaultCenter];
-        [center addObserver:self
-                   selector:@selector(applicationWillEnterForeground:)
-                       name:UIApplicationWillEnterForegroundNotification
-                     object:nil];
-
-        [center addObserver:self
-                   selector:@selector(applicationDidEnterBackground:)
-                       name:UIApplicationDidEnterBackgroundNotification
-                     object:nil];
-    }
-    return self;
+    NSLog(@"jerry - 1017 dealloc UniPage: %@", self);
 }
 
 - (void)layoutSubviews {
@@ -68,23 +36,18 @@
 - (void)pushNamed:(NSString*)routePath param:(NSDictionary *)args {
     NSAssert(routePath != nil, @"routePath cannot be nil");
     NSAssert(args != nil, @"args cannot be nil");
-    
-    NSDictionary *params = @{
-        UNI_PAGE_CHANNEL_PARAMS_PATH: routePath,
-        UNI_PAGE_CHANNEL_PARAMS_PARAMS: args
-    };
-    
-    [self.channel invokeMethod:UNI_PAGE_ROUTE_PUSH_NAMED arguments:params];
+
+    if (self.delegate && [self.delegate respondsToSelector:@selector(pushNamed:param:)]) {
+        [self.delegate pushNamed:routePath param: args];
+    }
 }
 
 - (void)pop:(id)result {
     NSAssert(result != nil, @"result cannot be nil");
     
-    NSDictionary *params = @{
-        UNI_PAGE_CHANNEL_PARAMS_PARAMS: result
-    };
-    
-    [self.channel invokeMethod:UNI_PAGE_ROUTE_POP arguments:params];
+    if (self.delegate && [self.delegate respondsToSelector:@selector(pop:)]) {
+        [self.delegate pop:result];
+    }
 }
 
 - (void)invoke:(NSString*)methodName arguments:(id _Nullable)params {
@@ -96,14 +59,9 @@
         result:(FlutterResult _Nullable)callback {
     NSAssert(methodName != nil, @"methodName cannot be nil");
     
-    NSDictionary *arguments = @{
-        UNI_PAGE_CHANNEL_VIEW_TYPE: self.viewType,
-        UNI_PAGE_CHANNEL_VIEW_ID: @(self.viewId),
-        UNI_PAGE_CHANNEL_METHOD_NAME: methodName,
-        UNI_PAGE_CHANNEL_PARAMS_PARAMS: params != nil ? params : @{},
-    };
-    
-    [self.channel invokeMethod:UNI_PAGE_CHANNEL_INVOKE arguments:arguments result:callback];
+    if (self.delegate && [self.delegate respondsToSelector:@selector(invoke:arguments:result:)]) {
+        [self.delegate invoke:methodName arguments:params result:callback];
+    }
 }
 
 - (id)onMethodCall:(NSString*)methodName params:(NSDictionary *)args {
@@ -111,15 +69,27 @@
 }
 
 - (int64_t)getViewId {
-    return self.viewId;
+    int64_t viewId = -1;
+    if (self.delegate && [self.delegate respondsToSelector:@selector(getViewId)]) {
+        viewId = [self.delegate getViewId];
+    }
+    return viewId;
 }
 
 - (NSDictionary*)getCreationParams {
-    return self.arguments;
+    NSDictionary *params;
+    if (self.delegate && [self.delegate respondsToSelector:@selector(getCreationParams)]) {
+        params = [self.delegate getCreationParams];
+    }
+    return params;
 }
 
 - (NSString*)getViewType {
-    return self.viewType;
+    NSString *viewType;
+    if (self.delegate && [self.delegate respondsToSelector:@selector(getViewType)]) {
+        viewType = [self.delegate getViewType];
+    }
+    return viewType;
 }
 
 
@@ -128,7 +98,7 @@
 }
 
 - (void)postCreate {
-    
+    self.ownerId = [[self currentController] hash];
 }
 
 - (void)onForeground {
@@ -143,6 +113,10 @@
     
 }
 
+- (NSUInteger)getOwnerId {
+    return self.ownerId;
+}
+
 #pragma mark - Notifications
 
 - (void)applicationWillEnterForeground:(NSNotification*)notification {
@@ -151,32 +125,6 @@
 
 - (void)applicationDidEnterBackground:(NSNotification*)notification {
   [self onBackground];
-}
-
-#pragma mark - FlutterPlatformView
-
-/// 返回真正的视图
-- (UIView *)view {
-    [self onCreate];
-    return self;
-}
-
-#pragma mark - private methods
-
-- (NSString*)createChannelName:(NSString*)viewType viewId:(int64_t)viewId {
-    return [NSString stringWithFormat:@"%@.%@.%lld", UNI_PAGE_CHANNEL, viewType, viewId];
-}
-
-- (void)onMethodCall:(FlutterMethodCall *)call result:(FlutterResult)result {
-    if ([call.method isEqualToString:UNI_PAGE_CHANNEL_INVOKE]) {
-        id args = call.arguments;
-        NSString *methodName = [args objectForKey:UNI_PAGE_CHANNEL_METHOD_NAME];
-        id params = [args objectForKey:UNI_PAGE_CHANNEL_PARAMS_PARAMS];
-        id ret = [self onMethodCall:methodName params:params];
-        result(ret);
-        return;
-    }
-    result(nil);
 }
 
 @end

--- a/packages/unify_uni_page/ios/Classes/UniPageContainer.h
+++ b/packages/unify_uni_page/ios/Classes/UniPageContainer.h
@@ -1,0 +1,28 @@
+//
+//  UniPageContainer.h
+//  unify_uni_page
+//
+//  Created by jerry on 2024/10/17.
+//
+
+#import <Foundation/Foundation.h>
+#import <Flutter/Flutter.h>
+#import "UniPageProtocol.h"
+
+NS_ASSUME_NONNULL_BEGIN
+@class UniPage;
+
+@interface UniPageContainer : NSObject<FlutterPlatformView, UniPageProtocol>
+- (instancetype)initWithWithFrame:(CGRect)frame
+                         viewType:(NSString*)viewType
+                   viewIdentifier:(int64_t)viewId
+                        arguments:(NSDictionary *)args
+                  binaryMessenger:(NSObject<FlutterBinaryMessenger>*)messenger;
+
+- (void)setupUniPage:(UniPage*)uniPage;
+
+- (void)addFlutterViewControllerWillDeallocObserver:(NSString*)noticeName;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/unify_uni_page/ios/Classes/UniPageContainer.m
+++ b/packages/unify_uni_page/ios/Classes/UniPageContainer.m
@@ -1,0 +1,202 @@
+//
+//  UniPageContainer.m
+//  unify_uni_page
+//
+//  Created by jerry on 2024/10/17.
+//
+
+#import "UniPageContainer.h"
+#import "UniPageConstants.h"
+#import "UniPage.h"
+#import "UIView+GetController.h"
+
+@interface UniPageContainer()<FlutterPlatformView>
+
+@property (nonatomic, copy) NSString *viewType;
+@property (nonatomic, assign) int64_t viewId;
+@property (nonatomic, strong) NSDictionary *arguments;
+@property (nonatomic, strong) FlutterMethodChannel *channel;
+@property (nonatomic, strong) FlutterMethodChannel *disposeChannel;
+@property (nonatomic, assign) BOOL isPosted;
+@property (nonatomic, strong) UniPage *uniPage;
+
+@end
+
+@implementation UniPageContainer
+
+- (void)dealloc {
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
+    NSLog(@"jerry - 1017 dealloc UniPageContainer: %@", self);
+}
+
+- (instancetype)initWithWithFrame:(CGRect)frame
+                         viewType:(NSString*)viewType
+                   viewIdentifier:(int64_t)viewId
+                        arguments:(NSDictionary *)args
+                  binaryMessenger:(NSObject<FlutterBinaryMessenger>*)messenger {
+    if ([super init]) {
+        self.viewId = viewId;
+        self.viewType = viewType;
+        self.arguments = args;
+        self.channel = [FlutterMethodChannel methodChannelWithName:self.channelName binaryMessenger:messenger];
+        __weak __typeof(self) weakSelf = self;
+        [self.channel setMethodCallHandler:^(FlutterMethodCall * _Nonnull call, FlutterResult  _Nonnull result) {
+            __strong __typeof(weakSelf) strongSelf = weakSelf;
+            [strongSelf onMethodCall:call result:result];
+        }];
+        
+        self.disposeChannel = [FlutterMethodChannel methodChannelWithName:self.disposeChannelName binaryMessenger:messenger];
+        [self.disposeChannel setMethodCallHandler:^(FlutterMethodCall * _Nonnull call, FlutterResult  _Nonnull result) {
+            __strong __typeof(weakSelf) strongSelf = weakSelf;
+            [strongSelf onDispose];
+        }];
+        
+        NSNotificationCenter* center = [NSNotificationCenter defaultCenter];
+        [center addObserver:self
+                   selector:@selector(applicationWillEnterForeground:)
+                       name:UIApplicationWillEnterForegroundNotification
+                     object:nil];
+
+        [center addObserver:self
+                   selector:@selector(applicationDidEnterBackground:)
+                       name:UIApplicationDidEnterBackgroundNotification
+                     object:nil];
+    }
+    return self;
+}
+
+- (void)setupUniPage:(UniPage*)uniPage {
+    self.uniPage = uniPage;
+}
+
+- (id)onMethodCall:(NSString*)methodName params:(NSDictionary *)args {
+    return [self.uniPage onMethodCall:methodName params:args];
+}
+
+- (void)onDispose {
+    [self.disposeChannel setMethodCallHandler:nil];
+    [self.uniPage onDispose];
+}
+
+- (void)addFlutterViewControllerWillDeallocObserver:(NSString*)noticeName {
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(onFlutterViewControllerWillDealloc:) name:noticeName object:nil];
+}
+
+#pragma mark - UniPageProtocol
+
+- (void)pushNamed:(NSString*)routePath param:(NSDictionary *)args {
+    NSAssert(routePath != nil, @"routePath cannot be nil");
+    NSAssert(args != nil, @"args cannot be nil");
+    
+    NSDictionary *params = @{
+        UNI_PAGE_CHANNEL_PARAMS_PATH: routePath,
+        UNI_PAGE_CHANNEL_PARAMS_PARAMS: args
+    };
+    
+    [self.channel invokeMethod:UNI_PAGE_ROUTE_PUSH_NAMED arguments:params];
+}
+
+- (void)pop:(id)result {
+    NSAssert(result != nil, @"result cannot be nil");
+    
+    NSDictionary *params = @{
+        UNI_PAGE_CHANNEL_PARAMS_PARAMS: result
+    };
+    
+    [self.channel invokeMethod:UNI_PAGE_ROUTE_POP arguments:params];
+}
+
+- (void)invoke:(NSString*)methodName
+     arguments:(id _Nullable)params
+        result:(FlutterResult _Nullable)callback {
+    NSAssert(methodName != nil, @"methodName cannot be nil");
+    
+    NSDictionary *arguments = @{
+        UNI_PAGE_CHANNEL_VIEW_TYPE: self.viewType,
+        UNI_PAGE_CHANNEL_VIEW_ID: @(self.viewId),
+        UNI_PAGE_CHANNEL_METHOD_NAME: methodName,
+        UNI_PAGE_CHANNEL_PARAMS_PARAMS: params != nil ? params : @{},
+    };
+    
+    [self.channel invokeMethod:UNI_PAGE_CHANNEL_INVOKE arguments:arguments result:callback];
+}
+
+- (int64_t)getViewId {
+    return self.viewId;
+}
+
+- (NSDictionary*)getCreationParams {
+    return self.arguments;
+}
+
+- (NSString*)getViewType {
+    return self.viewType;
+}
+
+#pragma mark - FlutterPlatformView
+
+/// 返回真正的视图
+- (UIView *)view {
+    UIView *container = UIView.new;
+    [container addSubview:self.uniPage];
+
+    /*
+     下面约束的作用是子视图完全撑开父视图，保持子视图和父视图四周边距紧邻着
+     */
+    [self.uniPage setTranslatesAutoresizingMaskIntoConstraints:NO];
+    NSLayoutConstraint* leftConstraint = [NSLayoutConstraint constraintWithItem:self.uniPage attribute:NSLayoutAttributeLeft relatedBy:NSLayoutRelationEqual toItem:container attribute:NSLayoutAttributeLeft multiplier:1.0 constant:0.0];
+    NSLayoutConstraint* rightConstraint = [NSLayoutConstraint constraintWithItem:self.uniPage attribute:NSLayoutAttributeRight relatedBy:NSLayoutRelationEqual toItem:container attribute:NSLayoutAttributeRight multiplier:1.0 constant:0.0];
+    NSLayoutConstraint* topConstraint = [NSLayoutConstraint constraintWithItem:self.uniPage attribute:NSLayoutAttributeTop relatedBy:NSLayoutRelationEqual toItem:container attribute:NSLayoutAttributeTop multiplier:1.0 constant:0.0];
+    NSLayoutConstraint* bottomConstraint = [NSLayoutConstraint constraintWithItem:self.uniPage attribute:NSLayoutAttributeBottom relatedBy:NSLayoutRelationEqual toItem:container attribute:NSLayoutAttributeBottom multiplier:1.0 constant:0.0];
+    if (@available(iOS 8.0, *)) {
+        leftConstraint.active = YES;
+        rightConstraint.active = YES;
+        topConstraint.active = YES;
+        bottomConstraint.active = YES;
+    } else {
+        [container addConstraints:@[leftConstraint, rightConstraint, topConstraint, bottomConstraint]];
+    }
+    
+    [self.uniPage onCreate];
+    return container;
+}
+
+#pragma mark - private methods
+
+- (NSString*)createChannelName:(NSString*)viewType viewId:(int64_t)viewId suffix:(NSString*)suffix{
+    NSString *suffixStr = suffix ? [NSString stringWithFormat:@".%@", suffix] : @"";
+    return [NSString stringWithFormat:@"%@.%@.%lld%@", UNI_PAGE_CHANNEL, viewType, viewId, suffixStr];
+}
+
+- (void)onMethodCall:(FlutterMethodCall *)call result:(FlutterResult)result {
+    if ([call.method isEqualToString:UNI_PAGE_CHANNEL_INVOKE]) {
+        id args = call.arguments;
+        NSString *methodName = [args objectForKey:UNI_PAGE_CHANNEL_METHOD_NAME];
+        id params = [args objectForKey:UNI_PAGE_CHANNEL_PARAMS_PARAMS];
+        id ret = [self onMethodCall:methodName params:params];
+        result(ret);
+        return;
+    }
+    result(nil);
+}
+
+- (NSString*)channelName {
+    return [self createChannelName:self.viewType viewId:self.viewId suffix:nil];
+}
+
+- (NSString*)disposeChannelName {
+    return [self createChannelName:self.viewType viewId:self.viewId suffix:@"dispose"];
+}
+
+- (void)onFlutterViewControllerWillDealloc:(id)notification {
+    NSUInteger noticeVCId = [[notification object] hash];
+    NSUInteger curOwnerId = [self.uniPage getOwnerId];
+    NSLog(@"jerry - 1017 notice noticeVCId = %lu unipage = %@", (unsigned long)noticeVCId, self.uniPage);
+    NSLog(@"jerry - 1017 notice curOwnerId = %lu unipage = %@", (unsigned long)curOwnerId, self.uniPage);
+    if (curOwnerId == noticeVCId) {
+        [self.uniPage removeFromSuperview];
+        self.uniPage = nil;
+    }
+}
+
+@end

--- a/packages/unify_uni_page/ios/Classes/UniPageProtocol.h
+++ b/packages/unify_uni_page/ios/Classes/UniPageProtocol.h
@@ -1,0 +1,38 @@
+//
+//  UniPageProtocol.h
+//  unify_uni_page
+//
+//  Created by jerry on 2024/10/17.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@protocol UniPageProtocol <NSObject>
+
+/// 调用指定的 Flutter 侧方法，并向其传递指定参数，可异步接收返回结果
+/// - Parameters:
+///   - methodName: 要调用的 Flutter 侧方法名
+///   - params: 传递的参数。注意：参数必须是此Channel关联的编解码器支持的类型
+///   - callback: 接收异步结果而使用的回调
+- (void)invoke:(NSString*)methodName
+     arguments:(id _Nullable)params
+        result:(FlutterResult _Nullable)callback;
+
+- (void)pushNamed:(NSString*)routePath param:(NSDictionary*)args;
+
+- (void)pop:(id)result;
+
+/// 获取viewId
+- (int64_t)getViewId;
+
+/// 获取Flutter传递过来的嵌原生页面参数
+- (NSDictionary*)getCreationParams;
+
+/// 获取UniPage对应的 viewType
+- (NSString*)getViewType;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/unify_uni_page/ios/Classes/UnifyUniPagePlugin.h
+++ b/packages/unify_uni_page/ios/Classes/UnifyUniPagePlugin.h
@@ -8,4 +8,9 @@
 ///   - pageType:  对齐 Flutter 的 viewType
 + (void)registerUniPage:(Class)clsName viewType:(NSString*)viewType;
 
+
+/// 注册 Flutter VC将销毁的通知监听
+/// - Parameter noticeName: 容器自定义的通知名称
++ (void)registerFlutterViewControllerWillDeallocObserver:(NSString*)noticeName;
+
 @end

--- a/packages/unify_uni_page/ios/Classes/UnifyUniPagePlugin.m
+++ b/packages/unify_uni_page/ios/Classes/UnifyUniPagePlugin.m
@@ -1,8 +1,11 @@
 #import "UnifyUniPagePlugin.h"
 #import "AbsUniPageFactory.h"
+#import "UniPageContainer.h"
 #import "UniPage.h"
 
 static NSMutableDictionary<NSString*, Class> *pageRegister;
+
+static NSMutableDictionary<NSString*, NSString*> *noticeNameRegister;
 
 @implementation UnifyUniPagePlugin
 
@@ -14,17 +17,41 @@ static NSMutableDictionary<NSString*, Class> *pageRegister;
     dispatch_once(&onceToken, ^{
         if (pageRegister == nil) {
             pageRegister = [NSMutableDictionary new];
+            noticeNameRegister = [NSMutableDictionary new];
         }
     });
     
     pageRegister[viewType] = clsName;
 }
 
++ (void)registerFlutterViewControllerWillDeallocObserver:(NSString*)noticeName {
+    NSAssert(noticeName != nil, @"noticeName cannot be nil");
+    for (NSString *key in pageRegister.allKeys) {
+        noticeNameRegister[key] = noticeName;
+    }
+}
+
 + (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar>*)registrar {
     for (NSString *key in pageRegister.allKeys) {
         Class cls = pageRegister[key];
-        [registrar registerViewFactory:[[AbsUniPageFactory alloc] init:^UniPage * _Nonnull(CGRect frame, int64_t viewId, id  _Nullable args) {
-            return [[cls alloc] initWithWithFrame:frame viewType:key viewIdentifier:viewId arguments:args binaryMessenger:[registrar messenger]];
+        [registrar registerViewFactory:[[AbsUniPageFactory alloc] init:^UniPageContainer * _Nonnull(CGRect frame, int64_t viewId, id  _Nullable args) {
+            /*
+              这块构造 UniPageContainer->UniPage,而不是直接返回 UniPage 的主要目的是：
+                在混合开发场景中，即： NA -> Flutter(wedget 使用了嵌原生)，如果直接侧滑返回的话，会造成 UniPage 泄漏。
+                业务逻辑大多是在UniPage中的，UniPage泄漏是不可接受的。
+              采用 UniPageContainer->UniPage 的结构，经过巧妙设计，可以解决 NA -> Flutter(wedget 使用了嵌原生) 场景中 UniPage 的泄漏问题
+             */
+            UniPageContainer *container = [[UniPageContainer alloc] initWithWithFrame:frame viewType:key viewIdentifier:viewId arguments:args binaryMessenger:[registrar messenger]];
+            
+            if ([noticeNameRegister objectForKey:key] != NULL) {
+                [container addFlutterViewControllerWillDeallocObserver:[noticeNameRegister objectForKey:key]];
+            }
+            NSLog(@"jerry - 1017 create UniPageContainer: %@", container);
+            UniPage *page = [[cls alloc] init];
+            page.delegate = container;
+            [container setupUniPage:page];
+            NSLog(@"jerry - 1017 create UniPage:%@", page);
+            return container;
         }] withId:key];
     }
 }

--- a/packages/unify_uni_page/lib/src/uni_page.dart
+++ b/packages/unify_uni_page/lib/src/uni_page.dart
@@ -7,9 +7,11 @@ import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:unify_uni_page/unify_uni_page.dart';
 
+import 'constants.dart';
+
 typedef CommonParamsCallback = Map<String, dynamic> Function();
 
-class UniPage extends StatelessWidget {
+class UniPage extends StatefulWidget {
   const UniPage(this.viewType,
       {Key? key,
       this.createParams,
@@ -23,10 +25,15 @@ class UniPage extends StatelessWidget {
   final UniPageController? controller;
 
   @override
+  State<StatefulWidget> createState() => _UniPageState();
+}
+
+class _UniPageState extends State<UniPage> {
+  @override
   Widget build(BuildContext context) {
     Map<String, dynamic> finalCreateParams = {};
-    finalCreateParams.addAll(createParams ?? {});
-    finalCreateParams.addAll(onCreateCommonParams?.call() ?? {});
+    finalCreateParams.addAll(widget.createParams ?? {});
+    finalCreateParams.addAll(widget.onCreateCommonParams?.call() ?? {});
     if (Platform.isIOS) {
       return UiKitView(
         viewType: viewType,
@@ -38,7 +45,7 @@ class UniPage extends StatelessWidget {
         creationParams: finalCreateParams,
         creationParamsCodec: const StandardMessageCodec(),
         onPlatformViewCreated: (viewId) {
-          controller?.init(context, viewType, viewId);
+          widget.controller?.init(context, viewType, viewId);
         },
       );
     }
@@ -55,7 +62,7 @@ class UniPage extends StatelessWidget {
               });
         },
         onCreatePlatformView: (params) {
-          controller?.init(context, viewType, params.id);
+          widget.controller?.init(context, viewType, params.id);
           return PlatformViewsService.initSurfaceAndroidView(
               id: params.id,
               viewType: viewType,
@@ -69,5 +76,21 @@ class UniPage extends StatelessWidget {
             ..create();
         },
         viewType: viewType);
+  }
+
+  @override
+  void dispose() {
+    _syncDisposeEvent();
+    super.dispose();
+  }
+
+  get viewType => widget.viewType;
+  get viewId => widget.controller?.viewId;
+
+  void _syncDisposeEvent() {
+    String channelName = '${createChannelName(viewType, viewId)}.dispose';
+    MethodChannel _disposeChannel = MethodChannel(channelName);
+    _disposeChannel.invokeMethod<void>('dispose');
+    print('jerry => call _syncDisposeEvent');
   }
 }


### PR DESCRIPTION
修复iOS侧滑返回，UniPage不释放问题